### PR TITLE
docs: update README for Laravel 12 / PHP 8.3 stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 ** DEMO **
 
 ## 說明
-本專案為使用 Laravel 5.8 與 Vue.js 2.7 開發的範例應用。
+本專案為使用 Laravel 12 與 Vue.js 2.7 開發的電商範例應用（含後台管理）。
 
 ## 技術棧 (Tech Stack)
-- **Backend**: Laravel Framework 5.8.*
-- **Frontend**: Vue.js 2.7.16, Bootstrap 3.4.1
+- **Backend**: Laravel Framework 12.x（PHP 8.3）
+- **Frontend**: Vue.js 2.7.16、Bootstrap 3.4.1（前台）/ AdminLTE 3（後台）
 - **Build Tool**: Webpack 5.89+, Laravel Mix 6.0+
+- **Database**: MySQL（透過 Docker）
+- **Testing**: PHPUnit 11（SQLite in-memory）
+- **執行環境**: Docker（PHP-FPM + Nginx + MySQL + phpMyAdmin）
 
 ## 安裝步驟
 *於命令列執行下列指令*
@@ -38,6 +41,23 @@
    $ npm run production
    ```
 
+## 測試 (Testing)
+本專案使用 PHPUnit 11，測試資料庫為 SQLite in-memory（設定於 `php/phpunit.xml`），無需另外準備 MySQL。
+
+```bash
+# 完整測試套件
+$ docker-compose run --rm php vendor/bin/phpunit
+
+# 單一測試套件
+$ docker-compose run --rm php vendor/bin/phpunit --testsuite Unit
+$ docker-compose run --rm php vendor/bin/phpunit --testsuite Feature
+```
+
+## 服務存取
+- Web 應用：`localhost:8084`
+- phpMyAdmin：`localhost:8085`
+
 ## 注意事項
+- **PHP 版本**：執行環境為 PHP 8.3（由 `dockerfile/php/8.3/Dockerfile` 建置）。
 - **DB帳密**：請提前自行於 `.env` 設定資料庫連線資訊。
-- **Node.js 版本**：建議使用 Node.js 14+ 或 16+ 以配合 Webpack 5。
+- **Node.js 版本**：建議使用 Node.js 18+ 以配合 Webpack 5。


### PR DESCRIPTION
Updates `README.md` to match the modernized stack after #31 (Laravel 5.8→12, PHP 7.2→8.3).

- **Tech stack:** Laravel 12.x (PHP 8.3); admin panel noted as AdminLTE 3; added Database (MySQL), Testing (PHPUnit 11), Docker runtime
- **New Testing section:** PHPUnit 11 over SQLite in-memory, with full/per-suite commands
- **Service access:** web `localhost:8084`, phpMyAdmin `localhost:8085`
- **Notes:** PHP 8.3 (`dockerfile/php/8.3/Dockerfile`); Node.js note 14/16 → 18
- Frontend lines kept accurate (Vue 2.7 / Bootstrap 3.4 are unchanged — the frontend modernization is a separate follow-up)

All claims cross-checked against composer.json / Dockerfile / phpunit.xml / docker-compose.yml (doc-review: APPROVE).